### PR TITLE
DB dump changes for Question-description - Emojis inclusion

### DIFF
--- a/backend/database/keelcompass_dump_2.2.sql
+++ b/backend/database/keelcompass_dump_2.2.sql
@@ -142,7 +142,7 @@ CREATE TABLE `Questions` (
   `id` int NOT NULL AUTO_INCREMENT,
   `user_id` int NOT NULL,
   `title` varchar(255) NOT NULL,
-  `description` text,
+  `description` text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
   `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
   `status` int DEFAULT '0',
   PRIMARY KEY (`id`),


### PR DESCRIPTION
Changes to the DB Question -> description field to accommodate the Emojis as part of Retrieving or Posting Questions.

Create Question with Emoji:
<img width="544" alt="image" src="https://github.com/user-attachments/assets/4fe7a15e-6ae5-44e5-95c7-deb25feacc43" />

Retrieve Question with Emoji:
<img width="530" alt="image" src="https://github.com/user-attachments/assets/ad5ed44f-7337-4310-9956-c40a6aeb6921" />
