### PR TITLE
bugfix: adds inline Snackbar variant and stabilizes timer

### DIFF
--- a/frontend/src/components/Snackbar.tsx
+++ b/frontend/src/components/Snackbar.tsx
@@ -5,6 +5,7 @@ interface SnackbarProps {
   isOpen: boolean;
   onClose: () => void;
   duration?: number;
+  variant?: "fixed" | "inline";
 }
 
 const Snackbar: React.FC<SnackbarProps> = ({
@@ -12,27 +13,45 @@ const Snackbar: React.FC<SnackbarProps> = ({
   isOpen,
   onClose,
   duration = 5000,
+  variant = "fixed",
 }) => {
+  const onCloseRef = React.useRef(onClose);
+
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
   useEffect(() => {
     if (isOpen) {
-      const timer = setTimeout(() => {
-        onClose();
+      const timer = window.setTimeout(() => {
+        onCloseRef.current();
       }, duration);
 
-      return () => clearTimeout(timer);
+      return () => window.clearTimeout(timer);
     }
-  }, [isOpen, duration, onClose]);
+  }, [isOpen, duration]);
 
   if (!isOpen) return null;
 
+  const isInline = variant === "inline";
+
   return (
     <div
-      className="fixed z-50 flex items-center justify-between"
+      className={`flex items-center justify-between ${
+        isInline ? "mb-4 max-w-full" : "fixed z-50"
+      }`}
       style={{
-        bottom: 96,
-        right: 24,
-        width: 343,
-        height: 48,
+        ...(isInline
+          ? {
+              width: "100%",
+              minHeight: 48,
+            }
+          : {
+              bottom: 96,
+              right: 24,
+              width: 343,
+              height: 48,
+            }),
         borderRadius: 4,
         paddingTop: 3,
         paddingRight: 16,
@@ -70,7 +89,7 @@ const Snackbar: React.FC<SnackbarProps> = ({
             lineHeight: "100%",
             letterSpacing: 0,
             color: "#212121",
-            whiteSpace: "nowrap",
+            whiteSpace: isInline ? "normal" : "nowrap",
           }}
         >
           {message}

--- a/frontend/src/features/dashboard/questions/QuestionsSection.tsx
+++ b/frontend/src/features/dashboard/questions/QuestionsSection.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Interest } from "../../../utils/types";
 import { QuestionListItem, QuestionsResponse } from "../../../utils/types";
+import Snackbar from "../../../components/Snackbar";
 import QuestionItem from "./QuestionItem";
 import QuestionDetails from "./QuestionDetails";
 
@@ -27,6 +28,8 @@ interface QuestionsSectionProps {
   hasMore: boolean;
   isLoading: boolean;
   onLoadMore: () => void;
+  showSuccessSnackbar: boolean;
+  onSuccessSnackbarClose: () => void;
 }
 
 function QuestionsSection({
@@ -46,6 +49,8 @@ function QuestionsSection({
   hasMore,
   isLoading,
   onLoadMore,
+  showSuccessSnackbar,
+  onSuccessSnackbarClose,
 }: QuestionsSectionProps) {
   const [selectedQuestionId, setSelectedQuestionId] = useState<number | null>(
     null
@@ -93,6 +98,13 @@ function QuestionsSection({
     <div className="shadow-md rounded-lg p-4 mb-6 bg-gray-50 w-full h-full flex flex-col overflow-hidden">
       {/* Fixed Heading + Tabs */}
       <div className="mb-4 flex-shrink-0">
+        <Snackbar
+          message="Success - Your question posted!"
+          isOpen={showSuccessSnackbar}
+          onClose={onSuccessSnackbarClose}
+          duration={4000}
+          variant="inline"
+        />
         <div className="flex items-center justify-between">
           <h2 className="text-xl font-medium uppercase tracking-wide">Posts</h2>
           <div className="flex items-center bg-gray-100 rounded-md w-fit p-0.5 border border-gray-300">

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -15,7 +15,6 @@ import {
   getUserInterests,
 } from "../utils/store";
 import MainLayout from "../components/wrappers/MainLayout";
-import Snackbar from "../components/Snackbar";
 import SearchBar from "../features/dashboard/searchBar/SearchBar";
 import QuestionsSection from "../features/dashboard/questions/QuestionsSection";
 import MyInterests from "../features/dashboard/interests/MyInterests";
@@ -452,6 +451,8 @@ const Dashboard = () => {
               hasMore={hasMore}
               isLoading={isLoadingQuestions}
               onLoadMore={handleLoadMoreQuestions}
+              showSuccessSnackbar={showSuccessSnackbar}
+              onSuccessSnackbarClose={() => setShowSuccessSnackbar(false)}
             />
           )}
         </div>
@@ -551,12 +552,6 @@ const Dashboard = () => {
         </div>
       </div>
 
-      <Snackbar
-        message="Success - Your question posted!"
-        isOpen={showSuccessSnackbar}
-        onClose={() => setShowSuccessSnackbar(false)}
-        duration={4000}
-      />
     </MainLayout>
   );
 };

--- a/frontend/src/pages/QuestionCreate.tsx
+++ b/frontend/src/pages/QuestionCreate.tsx
@@ -13,7 +13,6 @@ import {
 } from "react-icons/fi";
 import { BsListOl } from "react-icons/bs";
 import DiscardModal from "../components/DiscardModal";
-import Snackbar from "../components/Snackbar";
 
 /* SVG assets */
 import EmojiIcon from "../assets/Emojiicon.svg";
@@ -239,8 +238,6 @@ function QuestionCreate({
   const [selectedCategoryIds, setSelectedCategoryIds] = useState<string[]>([]);
   const [catOpen, setCatOpen] = useState(false);
 
-  const [showSuccessSnackbar, setShowSuccessSnackbar] = useState(false);
-
   const [activeFormatting, setActiveFormatting] = useState({
     bold: false,
     italic: false,
@@ -396,13 +393,9 @@ function QuestionCreate({
       onQuestionCreated?.(questionId);
 
       setTitleError("");
-      setShowSuccessSnackbar(true);
-
-      setTimeout(() => {
-        finalNavigate("/dashboard", {
-          state: { showQuestionPostedSnackbar: true },
-        });
-      }, 500);
+      finalNavigate("/dashboard", {
+        state: { showQuestionPostedSnackbar: true },
+      });
     } catch (err: unknown) {
       setAttachmentError(getErrorMessage(err));
     }
@@ -733,13 +726,6 @@ function QuestionCreate({
         isOpen={showDiscardModal}
         onCancel={cancelDiscard}
         onConfirm={confirmDiscard}
-      />
-
-      <Snackbar
-        message="Success - Your question posted!"
-        isOpen={showSuccessSnackbar}
-        onClose={() => setShowSuccessSnackbar(false)}
-        duration={4000}
       />
 
       <div className="p-8">


### PR DESCRIPTION
Adds an inline display variant for the Snackbar so success messages can appear inside the posts header. Moves the success notification into the questions section and removes duplicate page-level snackbars. Uses a ref for onClose and window.setTimeout/clearTimeout to prevent stale-callback timer bugs. Adjusts styles and whitespace handling to support inline vs fixed presentations.

<img width="1716" height="1336" alt="image" src="https://github.com/user-attachments/assets/99663999-744c-46be-a2b1-3a22c476ad30" />
